### PR TITLE
use typeclass: array

### DIFF
--- a/machines/pluck.js
+++ b/machines/pluck.js
@@ -21,7 +21,7 @@ module.exports = {
     array: {
       friendlyName: 'Array of dictionaries',
       description: 'The array of dictionaries to iterate over.',
-      example: [{}],
+      typeclass: 'array',
       required: true
     },
 

--- a/machines/sort-dictionaries.js
+++ b/machines/sort-dictionaries.js
@@ -21,7 +21,7 @@ module.exports = {
     array: {
       friendlyName: 'Array of dictionaries',
       description: 'The array to sort.',
-      example: [{}],
+      typeclass: 'array',
       required: true
     },
 

--- a/machines/uniq-by.js
+++ b/machines/uniq-by.js
@@ -21,7 +21,7 @@ module.exports = {
     array: {
       friendlyName: 'Array of dictionaries',
       description: 'The array of dictionaries to remove duplicates from.',
-      example: [{}],
+      typeclass: 'array',
       required: true
     },
 


### PR DESCRIPTION
Using the example: `[{}]` enforces an array with objects that have no keys. In Treeline this means you can't use a bubble in place of the array (only works for typeclass) and you can't add any keys to the objects.
